### PR TITLE
Update DownloadListActivity.java

### DIFF
--- a/sample/src/com/lidroid/xutils/sample/DownloadListActivity.java
+++ b/sample/src/com/lidroid/xutils/sample/DownloadListActivity.java
@@ -117,7 +117,7 @@ public class DownloadListActivity extends Activity {
                 RequestCallBack callBack = handler.getRequestCallBack();
                 if (callBack instanceof DownloadManager.ManagerCallBack) {
                     DownloadManager.ManagerCallBack managerCallBack = (DownloadManager.ManagerCallBack) callBack;
-                    if (managerCallBack.getBaseCallBack() == null) {
+                    if (managerCallBack.getBaseCallBack() == null｜｜!(managerCallBack.getBaseCallBack() instanceof DownloadRequestCallBack)) {
                         managerCallBack.setBaseCallBack(new DownloadRequestCallBack());
                     }
                 }


### PR DESCRIPTION
解决使用此adapter 框架 使用不同viewholder，在多列表下，下同一文件时，多页面同时显示时，页面切换 adapter报错的问题。